### PR TITLE
Use Image trace and add low-res slices

### DIFF
--- a/dash_3d_viewer/slicer.py
+++ b/dash_3d_viewer/slicer.py
@@ -166,17 +166,14 @@ class DashVolumeSlicer:
             //slice_cache[new_index] = undefined;  // todo: disabled cache for now!
             // Maybe we do not need an update
             if (!data) {
-                // return window.dash_clientside.no_update;
                 data = lowres[index];
             }
-            //if (data == ori_figure.layout.images[0].source) {
             if (data == ori_figure.data[0].source) {
                 return window.dash_clientside.no_update;
             }
             // Otherwise, perform update
             console.log("updating figure");
             let figure = {...ori_figure};
-            //figure.layout.images[0].source = data;
             figure.data[0].source = data;
             return figure;
         }

--- a/dash_3d_viewer/slicer.py
+++ b/dash_3d_viewer/slicer.py
@@ -1,10 +1,13 @@
 import numpy as np
-from plotly.graph_objects import Figure
+from plotly.graph_objects import Figure, Image
 from dash import Dash
 from dash.dependencies import Input, Output, State
 from dash_core_components import Graph, Slider, Store
 
 from .utils import gen_random_id, img_array_to_uri
+
+
+empty_img_str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg=="
 
 
 class DashVolumeSlicer:
@@ -40,38 +43,27 @@ class DashVolumeSlicer:
             for i in range(self._max_index + 1)
         ]
 
+        # Create a placeholder trace
+        # todo: can add "%{z[0]}", but that would be the scaled value ...
+        trace = Image(source=empty_img_str, hovertemplate="(%{x}, %{y})<extra></extra>")
         # Create the figure object
-        fig = Figure()
+        fig = Figure(data=[trace])
         fig.update_layout(
             template=None,
             margin=dict(l=0, r=0, b=0, t=0, pad=4),
         )
         fig.update_xaxes(
             showgrid=False,
-            range=(0, slice_size[0]),
+            # range=(0, slice_size[0]),
             showticklabels=False,
             zeroline=False,
         )
         fig.update_yaxes(
             showgrid=False,
             scaleanchor="x",
-            range=(slice_size[1], 0),  # todo: allow flipping x or y
+            # range=(slice_size[1], 0),  # todo: allow flipping x or y
             showticklabels=False,
             zeroline=False,
-        )
-        # Add an empty layout image that we can populate from JS.
-        fig.add_layout_image(
-            dict(
-                source="",
-                xref="x",
-                yref="y",
-                x=0,
-                y=0,
-                sizex=slice_size[0],
-                sizey=slice_size[1],
-                sizing="contain",
-                layer="below",
-            )
         )
         # Wrap the figure in a graph
         # todo: or should the user provide this?
@@ -180,13 +172,15 @@ class DashVolumeSlicer:
                 // return window.dash_clientside.no_update;
                 data = lowres[index];
             }
-            if (data == ori_figure.layout.images[0].source) {
+            //if (data == ori_figure.layout.images[0].source) {
+            if (data == ori_figure.data[0].source) {
                 return window.dash_clientside.no_update;
             }
             // Otherwise, perform update
             console.log("updating figure");
             let figure = {...ori_figure};
-            figure.layout.images[0].source = data;
+            //figure.layout.images[0].source = data;
+            figure.data[0].source = data;
             return figure;
         }
         """.replace(

--- a/dash_3d_viewer/slicer.py
+++ b/dash_3d_viewer/slicer.py
@@ -7,9 +7,6 @@ from dash_core_components import Graph, Slider, Store
 from .utils import gen_random_id, img_array_to_uri
 
 
-empty_img_str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg=="
-
-
 class DashVolumeSlicer:
     """A slicer to show 3D image data in Dash."""
 
@@ -32,9 +29,9 @@ class DashVolumeSlicer:
         self._id = id
 
         # Get the slice size (width, height), and max index
-        arr_shape = list(volume.shape)
-        arr_shape.pop(self._axis)
-        slice_size = list(reversed(arr_shape))
+        # arr_shape = list(volume.shape)
+        # arr_shape.pop(self._axis)
+        # slice_size = list(reversed(arr_shape))
         self._max_index = self._volume.shape[self._axis] - 1
 
         # Prep low-res slices
@@ -45,7 +42,7 @@ class DashVolumeSlicer:
 
         # Create a placeholder trace
         # todo: can add "%{z[0]}", but that would be the scaled value ...
-        trace = Image(source=empty_img_str, hovertemplate="(%{x}, %{y})<extra></extra>")
+        trace = Image(source="", hovertemplate="(%{x}, %{y})<extra></extra>")
         # Create the figure object
         fig = Figure(data=[trace])
         fig.update_layout(
@@ -53,15 +50,15 @@ class DashVolumeSlicer:
             margin=dict(l=0, r=0, b=0, t=0, pad=4),
         )
         fig.update_xaxes(
-            showgrid=False,
             # range=(0, slice_size[0]),
+            showgrid=False,
             showticklabels=False,
             zeroline=False,
         )
         fig.update_yaxes(
+            # range=(slice_size[1], 0),  # todo: allow flipping x or y
             showgrid=False,
             scaleanchor="x",
-            # range=(slice_size[1], 0),  # todo: allow flipping x or y
             showticklabels=False,
             zeroline=False,
         )

--- a/dash_3d_viewer/utils.py
+++ b/dash_3d_viewer/utils.py
@@ -1,19 +1,25 @@
+import io
 import random
+import base64
 
 import PIL.Image
 import skimage
-from plotly.utils import ImageUriValidator
 
 
 def gen_random_id(n=6):
     return "".join(random.choice("abcdefghijklmnopqrtsuvwxyz") for i in range(n))
 
 
-def img_array_to_uri(img_array):
+def img_array_to_uri(img_array, new_size=None):
     img_array = skimage.util.img_as_ubyte(img_array)
     # todo: leverage this Plotly util once it becomes part of the public API (also drops the Pillow dependency)
     # from plotly.express._imshow import _array_to_b64str
     # return _array_to_b64str(img_array)
     img_pil = PIL.Image.fromarray(img_array)
-    uri = ImageUriValidator.pil_image_to_uri(img_pil)
-    return uri
+    if new_size:
+        img_pil.thumbnail(new_size)
+    # The below was taken from plotly.utils.ImageUriValidator.pil_image_to_uri()
+    f = io.BytesIO()
+    img_pil.save(f, format="PNG")
+    base64_str = base64.b64encode(f.getvalue()).decode()
+    return "data:image/png;base64," + base64_str


### PR DESCRIPTION
The idea is to show the low-res version of a slice while we wait for the actual slice to load.

* [x] Upload low-res images at the start, and use these while the high-res data is being loaded.
* [x] Use Image trace instead of layout image.

Notes:

* The figure flickered quite a bit when being updated (on Firefox). This was greatly reduced when moving to the Image trace.
* When updating the value to request the new high-res data, the client freezes (on Chrome more than on FF), so the updating of low-res slices is slowed/halted.
* If we could detect when the slider is released, we could request the full slice at that moment, resulting in a smoother experience.
* When we implement contrast limits ... these will invalidate the low-res textures too ...