### PR TITLE
Support for anisotropic data.

### DIFF
--- a/dash_3d_viewer/slicer.py
+++ b/dash_3d_viewer/slicer.py
@@ -12,13 +12,17 @@ class DashVolumeSlicer:
 
     Parameters:
       app (dash.Dash): the Dash application instance.
-      volume (ndarray): the 3D numpy array to slice through.
-        The dimensions are assumed to be in zyx order.
-      spacing (tuple of floats): The voxel size for each dimension (zyx).
+      volume (ndarray): the 3D numpy array to slice through. The dimensions
+        are assumed to be in zyx order. If this is not the case, you can
+        use ``np.swapaxes`` to make it so.
+      spacing (tuple of floats): The distance between voxels for each dimension (zyx).
         The spacing and origin are applied to make the slice drawn in
         "scene space" rather than "voxel space".
       origin (tuple of floats): The offset for each dimension (zyx).
       axis (int): the dimension to slice in. Default 0.
+      reverse_y (bool): Whether to reverse the y-axis, so that the origin of
+        the slice is in the top-left, rather than bottom-left. Default True.
+        (This sets the figure's yaxes ``autorange`` to either "reversed" or True.)
       scene_id (str): the scene that this slicer is part of. Slicers
         that have the same scene-id show each-other's positions with
         line indicators. By default this is a hash of ``id(volume)``.
@@ -44,7 +48,15 @@ class DashVolumeSlicer:
     _global_slicer_counter = 0
 
     def __init__(
-        self, app, volume, *, spacing=None, origin=None, axis=0, scene_id=None
+        self,
+        app,
+        volume,
+        *,
+        spacing=None,
+        origin=None,
+        axis=0,
+        reverse_y=True,
+        scene_id=None
     ):
         # todo: also implement xyz dim order?
         if not isinstance(app, Dash):
@@ -115,6 +127,7 @@ class DashVolumeSlicer:
             scaleanchor="x",
             showticklabels=False,
             zeroline=False,
+            autorange="reversed" if reverse_y else True,
         )
         # Wrap the figure in a graph
         # todo: or should the user provide this?

--- a/dash_3d_viewer/utils.py
+++ b/dash_3d_viewer/utils.py
@@ -32,3 +32,14 @@ def get_thumbnail_size_from_shape(shape, base_size):
     img_pil = PIL.Image.fromarray(img_array)
     img_pil.thumbnail((base_size, base_size))
     return img_pil.size
+
+
+def shape3d_to_size2d(shape, axis):
+    """Turn a 3d shape (z, y, x) into a local (x', y', z'),
+    where z' represents the dimension indicated by axis.
+    """
+    shape = list(shape)
+    axis_value = shape.pop(axis)
+    size = list(reversed(shape))
+    size.append(axis_value)
+    return tuple(size)

--- a/examples/slicer_with_1_plus_2_views.py
+++ b/examples/slicer_with_1_plus_2_views.py
@@ -25,13 +25,17 @@ vol1 = imageio.volread("imageio:stent.npz")
 
 vol2 = vol1[::3, ::2, :]
 spacing = 3, 2, 1
-origin = 110, 120, 140
+ori = 110, 120, 140
 
 
-slicer1 = DashVolumeSlicer(app, vol1, axis=1, origin=origin, scene_id="myscene")
-slicer2 = DashVolumeSlicer(app, vol1, axis=0, origin=origin, scene_id="myscene")
+slicer1 = DashVolumeSlicer(
+    app, vol1, axis=1, origin=ori, reverse_y=False, scene_id="scene1"
+)
+slicer2 = DashVolumeSlicer(
+    app, vol1, axis=0, origin=ori, reverse_y=False, scene_id="scene1"
+)
 slicer3 = DashVolumeSlicer(
-    app, vol2, axis=0, origin=origin, spacing=spacing, scene_id="myscene"
+    app, vol2, axis=0, origin=ori, spacing=spacing, reverse_y=False, scene_id="scene1"
 )
 
 app.layout = html.Div(

--- a/examples/slicer_with_1_plus_2_views.py
+++ b/examples/slicer_with_1_plus_2_views.py
@@ -3,10 +3,14 @@ An example with two slicers at the same axis, and one on another axis.
 This demonstrates how multiple indicators can be shown per axis.
 
 Sharing the same scene_id is enough for the slicers to show each-others
-position. If the same volume object is given, it works by default,
+position. If the same volume object would be given, it works by default,
 because the default scene_id is a hash of the volume object. Specifying
 a scene_id provides slice position indicators even when slicing through
 different volumes.
+
+Further, this example has one slider showing data with different spacing.
+Note how the indicators represent the actual position in "scene coordinates".
+
 """
 
 import dash
@@ -17,22 +21,29 @@ import imageio
 
 app = dash.Dash(__name__)
 
-vol = imageio.volread("imageio:stent.npz")
-slicer1 = DashVolumeSlicer(app, vol, axis=1, scene_id="myscene")
-slicer2 = DashVolumeSlicer(app, vol, axis=0, scene_id="myscene")
-slicer3 = DashVolumeSlicer(app, vol, axis=0, scene_id="myscene")
+vol1 = imageio.volread("imageio:stent.npz")
+
+vol2 = vol1[::3, ::2, :]
+spacing = 3, 2, 1
+origin = 110, 120, 140
+
+
+slicer1 = DashVolumeSlicer(app, vol1, axis=1, origin=origin, scene_id="myscene")
+slicer2 = DashVolumeSlicer(app, vol1, axis=0, origin=origin, scene_id="myscene")
+slicer3 = DashVolumeSlicer(
+    app, vol2, axis=0, origin=origin, spacing=spacing, scene_id="myscene"
+)
 
 app.layout = html.Div(
     style={
         "display": "grid",
-        "grid-template-columns": "40% 40%",
+        "gridTemplateColumns": "40% 40%",
     },
     children=[
         html.Div(
             [
                 html.H1("Coronal"),
                 slicer1.graph,
-                html.Br(),
                 slicer1.slider,
                 *slicer1.stores,
             ]
@@ -41,7 +52,6 @@ app.layout = html.Div(
             [
                 html.H1("Transversal 1"),
                 slicer2.graph,
-                html.Br(),
                 slicer2.slider,
                 *slicer2.stores,
             ]
@@ -51,7 +61,6 @@ app.layout = html.Div(
             [
                 html.H1("Transversal 2"),
                 slicer3.graph,
-                html.Br(),
                 slicer3.slider,
                 *slicer3.stores,
             ]

--- a/examples/slicer_with_2_views.py
+++ b/examples/slicer_with_2_views.py
@@ -17,7 +17,7 @@ slicer2 = DashVolumeSlicer(app, vol, axis=2)
 app.layout = html.Div(
     style={
         "display": "grid",
-        "grid-template-columns": "40% 40%",
+        "gridTemplateColumns": "40% 40%",
     },
     children=[
         html.Div(

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -15,9 +15,9 @@ app = dash.Dash(__name__)
 
 # Read volumes and create slicer objects
 vol = imageio.volread("imageio:stent.npz")
-slicer1 = DashVolumeSlicer(app, vol, axis=0)
-slicer2 = DashVolumeSlicer(app, vol, axis=1)
-slicer3 = DashVolumeSlicer(app, vol, axis=2)
+slicer1 = DashVolumeSlicer(app, vol, reverse_y=False, axis=0)
+slicer2 = DashVolumeSlicer(app, vol, reverse_y=False, axis=1)
+slicer3 = DashVolumeSlicer(app, vol, reverse_y=False, axis=2)
 
 # Calculate isosurface and create a figure with a mesh object
 verts, faces, _, _ = marching_cubes(vol, 300, step_size=2)

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -30,7 +30,7 @@ fig_mesh.add_trace(go.Mesh3d(x=z, y=y, z=x, opacity=0.2, i=k, j=j, k=i))
 app.layout = html.Div(
     style={
         "display": "grid",
-        "grid-template-columns": "40% 40%",
+        "gridTemplateColumns": "40% 40%",
     },
     children=[
         html.Div(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+from dash_3d_viewer.utils import shape3d_to_size2d
+
+from pytest import raises
+
+
+def test_shape3d_to_size2d():
+    # shape -> z, y, x
+    # size -> x, y, out-of-plane
+    assert shape3d_to_size2d((12, 13, 14), 0) == (14, 13, 12)
+    assert shape3d_to_size2d((12, 13, 14), 1) == (14, 12, 13)
+    assert shape3d_to_size2d((12, 13, 14), 2) == (13, 12, 14)
+
+    with raises(IndexError):
+        shape3d_to_size2d((12, 13, 14), 3)


### PR DESCRIPTION
*rebased*

This:
* Adds `spacing` and `origin` arguments to specify the position and scale of a volume.
* Update things accordingly: everything lives in "scene-coordinates" now.
* Updates the `slicer_with_1_plus_2_views.py` example to include one view with downsampled data.
* Add `reverse_y` argument.

